### PR TITLE
fixed InstallUtil.exe detection

### DIFF
--- a/sysmonconfig.xml
+++ b/sysmonconfig.xml
@@ -29,10 +29,7 @@
           <OriginalFileName name="technique_id=T1063,technique_name=Security Software Discovery,phase_name=Discovery" condition="is">fltMC.exe</OriginalFileName>
           <CommandLine name="technique_id=T1063,technique_name=Security Software Discovery,phase_name=Discovery" condition="contains">misc::mflt</CommandLine>
         </Rule>
-        <Rule name="InstallUtil" groupRelation="and">
-          <OriginalFileName name="technique_id=T1118,technique_name=InstallUtil,phase_name=Execution" condition="is">InstallUtil.exe</OriginalFileName>
-          <CommandLine name="technique_id=T1118,technique_name=InstallUtil,phase_name=Execution" condition="contains all">/logfile=;/LogToConsole=false;/U</CommandLine>
-        </Rule>
+        <OriginalFileName name="technique_id=T1118,technique_name=InstallUtil,phase_name=Execution" condition="contains">InstallUtil.exe</OriginalFileName>
         <OriginalFileName name="technique_id=T1033,technique_name=System Owner/User Discovery,phase_name=Discovery" condition="is">whoami.exe</OriginalFileName>
         <OriginalFileName name="technique_id=T1016,technique_name=System Network Configuration Discovery,phase_name=Discovery" condition="is">ipconfig.exe</OriginalFileName>
         <OriginalFileName name="technique_id=T1057,technique_name=Process Discovery,phase_name=Discovery" condition="is">tasklist.exe</OriginalFileName>


### PR DESCRIPTION
I tested the detection for InstallUtil applocker bypass and found that the original sysmon configuration wasn't able to detect it. The version in this pull request was able to detect it. I'm not a sysmon expert so what I did might not be optimal, however